### PR TITLE
Fix the shuffle feature

### DIFF
--- a/src/components/Board.vue
+++ b/src/components/Board.vue
@@ -17,7 +17,7 @@
       :category="category"
     >
     </SolvedCategory>
-    <WordGrid :words="unsolvedWords()" v-if="!gameOver" :key="wordGridKey" />
+    <WordGrid :words="unsolvedWords" v-if="!gameOver" :key="wordGridKey" />
     <div v-if="!gameOver" class="actions-container">
       <ActionButton @click="shuffleWords()" text="Shuffle" />
       <ActionButton @click="unselectWords()" text="Deselect All" />
@@ -59,6 +59,7 @@ export default {
   data() {
     return {
       wordGridKey: Math.random(),
+      prevWordGridKey: null,
     };
   },
   props: {
@@ -117,11 +118,8 @@ export default {
         });
     },
     shuffleWords() {
+      this.prevWordGridKey = this.wordGridKey;
       this.wordGridKey = Math.random();
-    },
-    unsolvedWords() {
-      const words = this.$store.state.words.filter((word) => !word.solved);
-      return _.shuffle(words);
     },
     showInstructions() {
       this.$store.dispatch("updateShowInstructionModal", { value: true });
@@ -133,6 +131,14 @@ export default {
         this.$store.state.numOfGuessesRemaining === 0 ||
         this.$store.state.categories.every((c) => c.solved)
       );
+    },
+    unsolvedWords() {
+      const words = this.$store.state.words.filter((word) => !word.solved);
+      if (this.wordGridKey === this.prevWordGridKey) {
+        return words;
+      } else {
+        return _.shuffle(words);
+      }
     },
   },
 };


### PR DESCRIPTION
The approach to implementing this feature was twofold:
1. force the wordGrid component to rerender by setting a key on the component and changing that key when the 'Shuffle' button is clicked.

2. Use a method instead of a computed property to get the words for the words prop passed to the the WordGrid component.

This approach had the unintended side effect of rearranging the words everytime the user submitted a guess. The words should only rearrange when the user taps the 'Shuffle' button.

FIX: Revert to a computed property for the 'words' prop. Set a new data property to the wordGridKey when the 'Shuffle' button is clicked and generate a new key. By comparing the 2 keys, we decide if a new order is required. The 2 keys will only be different if the 'Shuffle' button has been clicked and therefore the words need to be "shuffled".